### PR TITLE
Add -cpe flag to download CPE.BIN data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 
 # Output files
 /EPO.BIN
+/CPE.BIN
 /raw

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,11 @@ build-windows:
 	docker build --build-arg GOOS=windows . -t armstrong
 	docker run --rm --entrypoint cat armstrong /go/bin/windows_amd64/armstrong.exe > armstrong.exe
 
+build-linux-local:
+	go build armstrong.go
+	mv armstrong armstrong_linux_amd64
+
+clean-linux-local:
+	rm armstrong_linux_amd64
+
 .PHONY: build-linux build-windows

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ EPO.BIN is GPS Extended Prediction Orbit (EPO) satellite data valid for
 7 days, used to help speed up GPS locking on Garmin devices that support
 this.
 
-For Forerunner devices, the file should be copied to
-`GARMIN/REMOTESW/EPO.BIN` on the watch. 
+CPE.BIN is similar to EPO.BIN and used for some Sony GPS chipsets.
+
+For Forerunner and Vivoactive devices, the file should be copied to the following folder on the watch.
+- EPO: `GARMIN/REMOTESW/EPO.BIN`
+- CPE: `Primary/GARMIN/RemoteSW/CPE.BIN` 
 
 ## Alternatives
 
@@ -30,6 +33,7 @@ This [repository](https://github.com/StevenMaude/epo-bin) hosts a daily
 download of `EPO.BIN`.
 
 ## Usage
+Use the `-cpe` flag to download CPE data instead of EPO
 
 ### Download
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-Retrieve EPO.BIN GPS data from MediaTek's servers on any platform that you
+Retrieve EPO.BIN and CPE.BIN GPS data from MediaTek's servers on any platform that you
 can compile a Go binary for, rather than only those that support Garmin
 Connect. Since Garmin's software doesn't run natively on Linux, it's
 useful there.
@@ -15,7 +15,7 @@ CPE.BIN is similar to EPO.BIN and used for some Sony GPS chipsets.
 
 For Forerunner and Vivoactive devices, the file should be copied to the following folder on the watch.
 - EPO: `GARMIN/REMOTESW/EPO.BIN`
-- CPE: `Primary/GARMIN/RemoteSW/CPE.BIN` 
+- CPE: `Primary/GARMIN/RemoteSW/CPE.BIN`
 
 ## Alternatives
 

--- a/armstrong.go
+++ b/armstrong.go
@@ -30,8 +30,8 @@ import (
 // "…each EPO SET is 2304 bytes"
 const epoLength = 2304
 
-// retrieveData makes a HTTP request to get data and returns the body as []byte if successful.
-func retrieveData() ([]byte, error) {
+// retrieveDataEPO makes a HTTP request to get data and returns the body as []byte if successful.
+func retrieveDataEPO() ([]byte, error) {
 	url := "https://epodownload.mediatek.com/EPO.DAT"
 
 	c := &http.Client{
@@ -71,10 +71,10 @@ func trimEPOData(data []byte) []byte {
 	return data[:(epoSetsCount * epoLength)]
 }
 
-// main retrieves EPO data, checks it, cleans it and writes it to disk.
-func main() {
+// downloadFileEPO retrieves EPO data, checks it, cleans it and writes it to disk.
+func downloadFileEPO() {
 	fmt.Println("Retrieving EPO data from Mediatek's servers...")
-	rawEPOData, err := retrieveData()
+	rawEPOData, err := retrieveDataEPO()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Adds CPE download support via `-cpe` flag, if you're inclined to merge it. No worries if not though. :)

At first I tried to share a lot of the functions to keep it more concise, but the download process is different enough that it was just filling the code with if statements.

I haven't written Go code before, so there may be stylistic faux pas.